### PR TITLE
Remove make-widget

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ of how the versioning scheme that this project does not use is clearly superior
 to random natural numbers and how incrementing the minor version number
 indicates backward compatible changes, unless it does not.
 
+- 2019-09-29 — Removed `make-widget`. Widget creation is now done with
+  Common Lisp's `make-instance`.
 - 2019-09-29 — Add `combobox`, `file-upload` and support for v7.5 widgets.
 - 2019-09-27 — Add support for JupyterLab in Docker.
 - 2019-09-07 — Add system-wide installation method.

--- a/docs/jupyter-widgets.md
+++ b/docs/jupyter-widgets.md
@@ -223,9 +223,9 @@ Displays multiple widgets in a group. The widgets are laid out horizontally.
 
 ```common-lisp
 (use-package :jupyter-widgets)
-(defvar title-widget (make-widget 'html :value "<em>Box Example</em>"))
-(defvar slider (make-widget 'int-slider))
-(make-widget 'box :children (list title-widget slider))
+(defvar title-widget (make-instance 'html :value "<em>Box Example</em>"))
+(defvar slider (make-instance 'int-slider))
+(make-instance 'box :children (list title-widget slider))
 ```
 
 
@@ -1091,9 +1091,9 @@ Displays multiple widgets horizontally using the flexible box model.
 
 ```common-lisp
 (use-package :jupyter-widgets)
-(defvar title-widget (make-widget 'html :value "<em>Box Example</em>"))
-(defvar slider (make-widget 'int-slider))
-(make-widget 'h-box :children (list title-widget slider))
+(defvar title-widget (make-instance 'html :value "<em>Box Example</em>"))
+(defvar slider (make-instance 'int-slider))
+(make-instance 'h-box :children (list title-widget slider))
 ```
 
 
@@ -1599,18 +1599,6 @@ expose the shorthand.
 Link Widget
 
 
-## *Function* `make-widget`
-
-### Syntax
-
-```common-lisp
-(make-widget class &rest rest &key &allow-other-keys)
-```
-
-### Description
-
-Create a Jupyter widget and inform the frontend to create a synchronized model.
-
 
 ## *Generic Function* `on-button-click`
 
@@ -1684,7 +1672,7 @@ output area.
 
 ```common-lisp
 (use-package :jupyter-widgets)
-(defvar out (make-widget 'output))
+(defvar out (make-instance 'output))
 (with-output out
   (print "prints to output area")
 ```
@@ -2302,9 +2290,9 @@ Displays multiple widgets vertically using the flexible box model.
 
 ```common-lisp
 (use-package :jupyter-widgets)
-(defvar title-widget (make-widget 'html :value "<em>Box Example</em>"))
-(defvar slider (make-widget 'int-slider))
-(make-widget 'v-box :children (list title-widget slider))
+(defvar title-widget (make-instance 'html :value "<em>Box Example</em>"))
+(defvar slider (make-instance 'int-slider))
+(make-instance 'v-box :children (list title-widget slider))
 ```
 
 

--- a/examples/widgets.ipynb
+++ b/examples/widgets.ipynb
@@ -16,7 +16,7 @@
    "outputs": [],
    "source": [
     "(progn\n",
-    "    (defvar a-button (make-widget 'button :description \"Click me\"))\n",
+    "    (defvar a-button (make-instance 'button :description \"Click me\"))\n",
     "\n",
     "    (defmethod on-button-click ((w (eql a-button)))\n",
     "        (setf (widget-description w) \"I've been clicked.\"))\n",
@@ -31,7 +31,7 @@
    "outputs": [],
    "source": [
     "(progn\n",
-    "    (defvar a-int-slider (make-widget 'int-slider))\n",
+    "    (defvar a-int-slider (make-instance 'int-slider))\n",
     "    a-int-slider)"
    ]
   },

--- a/src/packages.lisp
+++ b/src/packages.lisp
@@ -112,7 +112,6 @@
     #:label
     #:layout
     #:link
-    #:make-widget
     #:on-button-click
     #:on-trait-change
     #:output

--- a/src/widgets/box.lisp
+++ b/src/widgets/box.lisp
@@ -23,9 +23,9 @@
 
 ```common-lisp
 (use-package :jupyter-widgets)
-(defvar title-widget (make-widget 'html :value \"<em>Box Example</em>\"))
-(defvar slider (make-widget 'int-slider))
-(make-widget 'box :children (list title-widget slider))
+(defvar title-widget (make-instance 'html :value \"<em>Box Example</em>\"))
+(defvar slider (make-instance 'int-slider))
+(make-instance 'box :children (list title-widget slider))
 ```"))
 
 (register-widget box)
@@ -86,9 +86,9 @@
 
 ```common-lisp
 (use-package :jupyter-widgets)
-(defvar title-widget (make-widget 'html :value \"<em>Box Example</em>\"))
-(defvar slider (make-widget 'int-slider))
-(make-widget 'h-box :children (list title-widget slider))
+(defvar title-widget (make-instance 'html :value \"<em>Box Example</em>\"))
+(defvar slider (make-instance 'int-slider))
+(make-instance 'h-box :children (list title-widget slider))
 ```"))
 
 (register-widget h-box)
@@ -118,9 +118,9 @@
 
 ```common-lisp
 (use-package :jupyter-widgets)
-(defvar title-widget (make-widget 'html :value \"<em>Box Example</em>\"))
-(defvar slider (make-widget 'int-slider))
-(make-widget 'v-box :children (list title-widget slider))
+(defvar title-widget (make-instance 'html :value \"<em>Box Example</em>\"))
+(defvar slider (make-instance 'int-slider))
+(make-instance 'v-box :children (list title-widget slider))
 ```"))
 
 (register-widget v-box)

--- a/src/widgets/button.lisp
+++ b/src/widgets/button.lisp
@@ -11,7 +11,7 @@
   (:default-initargs
     :%model-name "ButtonModel"
     :%view-name "ButtonView"
-    :style (make-widget 'button-style))
+    :style (make-instance 'button-style))
   (:documentation "Button widget.
 This widget has an `on-button-click` method that allows you to listen for the
 user clicking on the button.  The click event itself is stateless."))

--- a/src/widgets/dom-widget.lisp
+++ b/src/widgets/dom-widget.lisp
@@ -251,7 +251,7 @@ expose the shorthand."))
      :trait :unicode-list)
    (layout
      :initarg :layout
-     :initform (make-widget 'layout)
+     :initform (make-instance 'layout)
      :accessor widget-layout
      :documentation "Reference to layout widget."
      :trait :widget))

--- a/src/widgets/output.lisp
+++ b/src/widgets/output.lisp
@@ -35,7 +35,7 @@ output area.
 
 ```common-lisp
 (use-package :jupyter-widgets)
-(defvar out (make-widget 'output))
+(defvar out (make-instance 'output))
 (with-output out
   (print \"prints to output area\")
 ```"))

--- a/src/widgets/progress.lisp
+++ b/src/widgets/progress.lisp
@@ -11,7 +11,7 @@
   (:metaclass trait-metaclass)
   (:default-initargs
     :%view-name "ProgressView"
-    :style (make-widget 'progress-style)))
+    :style (make-instance 'progress-style)))
 
 
 (defclass float-progress (base-progress float-min-max-slots float-value-slot)

--- a/src/widgets/slider.lisp
+++ b/src/widgets/slider.lisp
@@ -16,7 +16,7 @@
      :trait :unicode))
   (:metaclass trait-metaclass)
   (:default-initargs
-    :style (make-widget 'slider-style)))
+    :style (make-instance 'slider-style)))
 
 
 (defclass number-slider (base-slider)

--- a/src/widgets/style.lisp
+++ b/src/widgets/style.lisp
@@ -120,4 +120,4 @@
      :trait :unicode))
   (:metaclass trait-metaclass)
   (:default-initargs
-    :style (make-widget 'description-style)))
+    :style (make-instance 'description-style)))


### PR DESCRIPTION
`make-widget` now redundant by usage of `initialize-instance` method. 