### PR TITLE
fix codemirror-mode

### DIFF
--- a/src/cl-jupyter/kernel.lisp
+++ b/src/cl-jupyter/kernel.lisp
@@ -20,7 +20,7 @@
     :mime-type "text/x-common-lisp"
     :file-extension ".lisp"
     :pygments-lexer "common-lisp"
-    :codemirror-mode "text/x-common-lisp"
+    :codemirror-mode "Common Lisp"
     :help-links '(("Common Lisp Documentation" . "https://common-lisp.net/documentation")
                   ("Common Lisp HyperSpec" . "http://www.lispworks.com/documentation/HyperSpec/Front/index.htm")
                   ("Practical Common Lisp" . "http://www.gigamonkeys.com/book/")


### PR DESCRIPTION
Codemirror error occurs when load common lisp notebook because of codemirror-mode "x-common-lisp" is passed to codemirror meta.js. I fixed kernel.lisp's default-initargs.

Error message when I load common lisp jupyter notebook:
> Notebook failed to load
> The error was:
> TypeError: ext.toLowerCase is not a function
> See the error console for details.

My environments:

> jupyter --version
> jupyter core     : 4.6.3
> jupyter-notebook : 6.0.3
> qtconsole        : not installed
> ipython          : 7.13.0
> ipykernel        : 5.2.0
> jupyter client   : 6.1.2
> jupyter lab      : not installed
> nbconvert        : 5.6.1
> ipywidgets       : 6.0.0
> nbformat         : 5.0.4
> traitlets        : 4.3.3
> 