### PR TITLE
Clasp source interface

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,7 +43,7 @@ jobs:
         asdf-add
     - name: Install kernel
       run: |
-        lisp -i ${{ matrix.lisp }} -e "(ql:quickload :common-lisp-jupyter)" -e "(clj:install)" -q
+        lisp -i ${{ matrix.lisp }} -e "(asdf:load-system :common-lisp-jupyter)" -e "(clj:install)" -q
     - name: Run kernel tests
       run: |
         pytest --verbose

--- a/src/cl-jupyter/inspect.lisp
+++ b/src/cl-jupyter/inspect.lisp
@@ -599,8 +599,7 @@
                 "Generic Function")
               (t
                 "Function"))
-            (or (documentation sym 'function)
-                #+clasp (sys:get-annotation sym 'documentation 'method))
+            (documentation sym 'function)
             (cons sym (lambda-list sym)))))
 
 

--- a/src/cl-jupyter/kernel.lisp
+++ b/src/cl-jupyter/kernel.lisp
@@ -569,28 +569,32 @@
 (defun eval-and-print (form aux-form breakpoints)
   (setf common-lisp-user::- form)
   (let* ((results (multiple-value-list
-                   #+ccl   (ccl::cheap-eval-in-environment form (kernel-environment jupyter:*kernel*))
-                   #+clasp (ext:eval-source form aux-form (kernel-environment jupyter:*kernel*))
-                    #+sbcl  (handler-bind ((sb-c::compiler-note #'muffle-warning))
-                              (let* ((sb-c::*source-paths* (make-hash-table :test 'eq))
-                                     (lambda (sb-impl::make-eval-lambda form))
-                                     (sb-c::*source-form-context-alist*
-                                       (acons lambda form
-                                              sb-c::*source-form-context-alist*)))
-                                (sb-c::find-source-paths form aux-form)
-                                (let ((fun (sb-c:compile-in-lexenv lambda (kernel-environment jupyter:*kernel*)
-                                                                   nil sb-c::*source-info*
-                                                                   aux-form nil nil)))
-                                  (trivial-do:dohash (source config (jupyter::kernel-breakpoints jupyter:*kernel*))
-                                    (declare (ignore source))
-                                    (dolist (breakpoint (jupyter::debug-configuration-breakpoints config))
-                                      (when (jupyter:debug-breakpoint-data breakpoint)
-                                        (sb-di::activate-breakpoint
-                                          (sb-di::deactivate-breakpoint
-                                            (jupyter:debug-breakpoint-data breakpoint))))))
-                                  (funcall fun))))
-                    #-(or ccl clasp sbcl)
-                            (eval form))))
+                   #+ccl
+                   (let ((ccl::*loading-toplevel-location* aux-form))
+                     (ccl::cheap-eval-in-environment form (kernel-environment jupyter:*kernel*)))
+                   #+clasp
+                   (ext:eval-source form aux-form (kernel-environment jupyter:*kernel*))
+                   #+sbcl
+                   (handler-bind ((sb-c::compiler-note #'muffle-warning))
+                     (let* ((sb-c::*source-paths* (make-hash-table :test 'eq))
+                            (lambda (sb-impl::make-eval-lambda form))
+                            (sb-c::*source-form-context-alist*
+                              (acons lambda form
+                                     sb-c::*source-form-context-alist*)))
+                       (sb-c::find-source-paths form aux-form)
+                       (let ((fun (sb-c:compile-in-lexenv lambda (kernel-environment jupyter:*kernel*)
+                                                          nil sb-c::*source-info*
+                                                          aux-form nil nil)))
+                         (trivial-do:dohash (source config (jupyter::kernel-breakpoints jupyter:*kernel*))
+                                            (declare (ignore source))
+                                            (dolist (breakpoint (jupyter::debug-configuration-breakpoints config))
+                                              (when (jupyter:debug-breakpoint-data breakpoint)
+                                                (sb-di::activate-breakpoint
+                                                 (sb-di::deactivate-breakpoint
+                                                  (jupyter:debug-breakpoint-data breakpoint))))))
+                         (funcall fun))))
+                   #-(or ccl clasp sbcl)
+                   (eval form))))
     (setf common-lisp-user::*** common-lisp-user::**
           common-lisp-user::** common-lisp-user::*
           common-lisp-user::* (car results)
@@ -618,13 +622,11 @@
                                                        :map ccl::*nx-source-note-map*
                                                        :save-source-text t)
         (unless (eq form stream)
-          (setf ccl::*loading-toplevel-location* location)
-          (eval-and-print form nil breakpoints)
+          (eval-and-print form location breakpoints)
           t)))
     #+clasp
     (source-path
-     (ext:with-source-location
-         ((ext:stream-source-location stream))
+     (ext:with-source-location ((ext:stream-source-location stream))
        (multiple-value-bind (form source)
            (ext:read-source stream nil stream nil
                             (kernel-environment kernel))

--- a/src/cl-jupyter/kernel.lisp
+++ b/src/cl-jupyter/kernel.lisp
@@ -569,12 +569,8 @@
 (defun eval-and-print (form aux-form breakpoints)
   (setf common-lisp-user::- form)
   (let* ((results (multiple-value-list
-                    #+ccl   (ccl::cheap-eval-in-environment form (kernel-environment jupyter:*kernel*))
-                    #+(or)  (funcall (clasp-cleavir::bir-compile-cst
-                                      (cst:list (cst:cst-from-expression 'lambda)
-                                                (cst:cst-from-expression nil)
-                                                aux-form)
-                                      clasp-cleavir::*clasp-env*))
+                   #+ccl   (ccl::cheap-eval-in-environment form (kernel-environment jupyter:*kernel*))
+                   #+clasp (ext:eval-source form aux-form (kernel-environment jupyter:*kernel*))
                     #+sbcl  (handler-bind ((sb-c::compiler-note #'muffle-warning))
                               (let* ((sb-c::*source-paths* (make-hash-table :test 'eq))
                                      (lambda (sb-impl::make-eval-lambda form))
@@ -593,7 +589,7 @@
                                           (sb-di::deactivate-breakpoint
                                             (jupyter:debug-breakpoint-data breakpoint))))))
                                   (funcall fun))))
-                    #-(or ccl sbcl)
+                    #-(or ccl clasp sbcl)
                             (eval form))))
     (setf common-lisp-user::*** common-lisp-user::**
           common-lisp-user::** common-lisp-user::*
@@ -624,12 +620,13 @@
           (setf ccl::*loading-toplevel-location* location)
           (eval-and-print form nil breakpoints)
           t)))
-    #+(or);clasp
+    #+clasp
     (source-path
-      (let ((cst (eclector.concrete-syntax-tree:read stream nil stream)))
-        (unless (eq cst stream)
-          (eval-and-print (concrete-syntax-tree:raw cst) cst breakpoints)
-          t)))
+     (multiple-value-bind (form source)
+         (ext:read-source stream nil stream nil
+                          (kernel-environment kernel))
+       (unless (eq form stream)
+         (eval-and-print form source breakpoints))))
     #+sbcl
     (source-path
       (with-accessors ((forms sb-c::file-info-forms)
@@ -686,25 +683,19 @@
                                      jupyter:*kernel* stream source-path breakpoints
                                      (source-line-column source-path 0))
             (go next))))
-      #+(or);clasp
+      #+clasp
       (with-open-file (stream source-path)
-        (prog* ((eclector.reader:*client* cmp::*cst-client*)
-                (eclector.readtable:*readtable* cl:*readtable*)
-                (*load-truename* (truename source-path))
-                (*load-pathname* source-path)
-                (cmp::*compile-file-pathname* source-path)
-                (cmp::*compile-file-truename* (truename source-path))
-                (cmp::*compile-file-source-debug-pathname* source-path)
-                (cmp::*compile-file-file-scope* (core:file-scope source-path))
-                (cmp::*compile-file-source-debug-lineno* 0)
-                (cmp::*compile-file-source-debug-offset* 0)
-                (core:*current-source-pos-info*))
-         repeat
-          (setf core:*current-source-pos-info* (cmp:compile-file-source-pos-info stream))
-          (when (jupyter:evaluate-form jupyter:*kernel* stream source-path breakpoints
-                                       (core::source-pos-info-lineno core:*current-source-pos-info*)
-                                       (1+ (core::source-pos-info-column core:*current-source-pos-info*)))
-            (go repeat))))
+        (ext:with-source-tracking (stream :pathname source-path)
+          (let ((*load-truename* (truename source-path))
+                (*load-pathname* source-path))
+            (tagbody
+             repeat
+               (ext:with-source-location
+                   ((ext:stream-source-location stream))
+                 (when (jupyter:evaluate-form jupyter:*kernel* stream source-path breakpoints
+                                              (ext:source-location-lineno (ext:current-source-location))
+                                              (1+ (ext:source-location-column (ext:current-source-location))))
+                   (go repeat)))))))
       #+sbcl
       (sb-c::with-compiler-error-resignalling
         (prog* ((sb-c::*last-message-count* (list* 0 nil nil))
@@ -720,7 +711,7 @@
           (when (jupyter:evaluate-form jupyter:*kernel* stream source-path breakpoints
                                        (car pos) (cdr pos))
             (go repeat))))
-      #-(or ccl sbcl)
+      #-(or ccl clasp sbcl)
       (with-tracking-stream (stream source-path)
         (prog* ((*load-truename* (truename source-path))
                 (*load-pathname* source-path)

--- a/src/cl-jupyter/kernel.lisp
+++ b/src/cl-jupyter/kernel.lisp
@@ -140,6 +140,7 @@
 
 
 (defun trim-frame-list (frames condition)
+  #+ecl (setf frames (remove-if-not #'frame-function-name frames))
   #+sbcl
   (when (typep condition 'sb-impl::step-condition)
     (setf frames (or (cdr (member-if (lambda (frame)
@@ -159,7 +160,6 @@
                                 :test #'equal)))
                  frames)
       frames))
-
 
 (defun frame-list ()
   #+ccl   (let (frames)
@@ -221,7 +221,7 @@
                                        (declare (ignore condition)))))))
   #+ecl   (multiple-value-bind (pathname position)
                                (system::bc-file (car frame))
-            (when file
+            (when pathname
               (multiple-value-call #'values pathname (source-line-column pathname position))))
   #+sbcl  (let* ((code-location (sb-di:frame-code-location frame))
                  (pathname (ignore-errors
@@ -244,12 +244,15 @@
                                                        :name (frame-name frame)
                                                        :data frame)))
             (multiple-value-bind (pathname line column)
-                                 (frame-source frame)
-              (when pathname
-                (setf (jupyter:debug-object-source instance)
-                      (make-instance 'jupyter:debug-source
-                                     :name (file-namestring pathname)
-                                     :path pathname)))
+                (frame-source frame)
+              (setf (jupyter:debug-object-source instance)
+                    (if pathname
+                        (make-instance 'jupyter:debug-source
+                                       :name (file-namestring pathname)
+                                       :path pathname)
+                        (make-instance 'jupyter:debug-source
+                                       :name ""
+                                       :path "")))
               (when line
                 (setf (jupyter:debug-object-line instance) line))
               (when column
@@ -574,6 +577,9 @@
                      (ccl::cheap-eval-in-environment form (kernel-environment jupyter:*kernel*)))
                    #+clasp
                    (ext:eval-source form aux-form (kernel-environment jupyter:*kernel*))
+                   #+ecl
+                   (let ((ext:*source-location* aux-form))
+                     (eval form))
                    #+sbcl
                    (handler-bind ((sb-c::compiler-note #'muffle-warning))
                      (let* ((sb-c::*source-paths* (make-hash-table :test 'eq))
@@ -593,7 +599,7 @@
                                                  (sb-di::deactivate-breakpoint
                                                   (jupyter:debug-breakpoint-data breakpoint))))))
                          (funcall fun))))
-                   #-(or ccl clasp sbcl)
+                   #-(or ccl clasp ecl sbcl)
                    (eval form))))
     (setf common-lisp-user::*** common-lisp-user::**
           common-lisp-user::** common-lisp-user::*
@@ -631,6 +637,13 @@
                           (kernel-environment kernel))
        (unless (eq form stream)
          (eval-and-print form source breakpoints)
+         t)))
+    #+ecl
+    (source-path
+     (let ((pos (file-position stream))
+           (form (read stream nil stream)))
+       (unless (eq form stream)
+         (eval-and-print form (cons source-path pos) breakpoints)
          t)))
     #+sbcl
     (source-path
@@ -716,12 +729,11 @@
       #-(or ccl clasp sbcl)
       (with-tracking-stream (stream source-path)
         (prog* ((*load-truename* (truename source-path))
-                (*load-pathname* source-path)
-                #+ecl ext:*source-location*)
+                (*load-pathname* source-path))
          repeat
-          #+ecl (setf ext:*source-location* (cons source-path (file-position stream)))
           (when (jupyter:evaluate-form jupyter:*kernel* stream source-path breakpoints
-                                       (tracking-stream-line stream) (tracking-stream-column stream))
+                                       (tracking-stream-line stream)
+                                       (tracking-stream-column stream))
             (go repeat)))))
     (t ; Fallback REPL
       (with-input-from-string (stream code)

--- a/src/cl-jupyter/kernel.lisp
+++ b/src/cl-jupyter/kernel.lisp
@@ -626,13 +626,12 @@
           t)))
     #+clasp
     (source-path
-     (ext:with-source-location ((ext:stream-source-location stream))
-       (multiple-value-bind (form source)
-           (ext:read-source stream nil stream nil
-                            (kernel-environment kernel))
-         (unless (eq form stream)
-           (eval-and-print form source breakpoints)
-           t))))
+     (multiple-value-bind (form source)
+         (ext:read-source stream nil stream nil
+                          (kernel-environment kernel))
+       (unless (eq form stream)
+         (eval-and-print form source breakpoints)
+         t)))
     #+sbcl
     (source-path
       (with-accessors ((forms sb-c::file-info-forms)

--- a/src/cl-jupyter/kernel.lisp
+++ b/src/cl-jupyter/kernel.lisp
@@ -605,7 +605,8 @@
     #+sbcl (update-breakpoints *load-pathname* breakpoints)))
 
 
-(defmethod jupyter:evaluate-form ((kernel kernel) stream source-path breakpoints &optional line column)
+(defmethod jupyter:evaluate-form
+    ((kernel kernel) stream source-path breakpoints &optional line column)
   (declare (ignore line column))
   (cond
     #+ccl
@@ -622,12 +623,14 @@
           t)))
     #+clasp
     (source-path
-     (multiple-value-bind (form source)
-         (ext:read-source stream nil stream nil
-                          (kernel-environment kernel))
-       (unless (eq form stream)
-         (eval-and-print form source breakpoints)
-         t)))
+     (ext:with-source-location
+         ((ext:stream-source-location stream))
+       (multiple-value-bind (form source)
+           (ext:read-source stream nil stream nil
+                            (kernel-environment kernel))
+         (unless (eq form stream)
+           (eval-and-print form source breakpoints)
+           t))))
     #+sbcl
     (source-path
       (with-accessors ((forms sb-c::file-info-forms)
@@ -690,12 +693,10 @@
           (prog ((*load-truename* (truename source-path))
                  (*load-pathname* source-path))
            repeat
-             (ext:with-source-location
-                 ((ext:stream-source-location stream))
-               (when (jupyter:evaluate-form jupyter:*kernel* stream source-path breakpoints
-                                            (ext:source-location-lineno (ext:current-source-location))
-                                            (1+ (ext:source-location-column (ext:current-source-location))))
-                 (go repeat))))))
+             (when (jupyter:evaluate-form jupyter:*kernel* stream source-path breakpoints
+                                          (ext:source-location-lineno (ext:current-source-location))
+                                          (1+ (ext:source-location-column (ext:current-source-location))))
+               (go repeat)))))
       #+sbcl
       (sb-c::with-compiler-error-resignalling
         (prog* ((sb-c::*last-message-count* (list* 0 nil nil))

--- a/src/cl-jupyter/kernel.lisp
+++ b/src/cl-jupyter/kernel.lisp
@@ -570,7 +570,7 @@
   (setf common-lisp-user::- form)
   (let* ((results (multiple-value-list
                     #+ccl   (ccl::cheap-eval-in-environment form (kernel-environment jupyter:*kernel*))
-                    #+clasp (funcall (clasp-cleavir::bir-compile-cst
+                    #+(or)  (funcall (clasp-cleavir::bir-compile-cst
                                       (cst:list (cst:cst-from-expression 'lambda)
                                                 (cst:cst-from-expression nil)
                                                 aux-form)
@@ -593,7 +593,7 @@
                                           (sb-di::deactivate-breakpoint
                                             (jupyter:debug-breakpoint-data breakpoint))))))
                                   (funcall fun))))
-                    #-(or ccl clasp sbcl)
+                    #-(or ccl sbcl)
                             (eval form))))
     (setf common-lisp-user::*** common-lisp-user::**
           common-lisp-user::** common-lisp-user::*
@@ -624,7 +624,7 @@
           (setf ccl::*loading-toplevel-location* location)
           (eval-and-print form nil breakpoints)
           t)))
-    #+clasp
+    #+(or);clasp
     (source-path
       (let ((cst (eclector.concrete-syntax-tree:read stream nil stream)))
         (unless (eq cst stream)
@@ -686,7 +686,7 @@
                                      jupyter:*kernel* stream source-path breakpoints
                                      (source-line-column source-path 0))
             (go next))))
-      #+clasp
+      #+(or);clasp
       (with-open-file (stream source-path)
         (prog* ((eclector.reader:*client* cmp::*cst-client*)
                 (eclector.readtable:*readtable* cl:*readtable*)
@@ -720,7 +720,7 @@
           (when (jupyter:evaluate-form jupyter:*kernel* stream source-path breakpoints
                                        (car pos) (cdr pos))
             (go repeat))))
-      #-(or ccl clasp sbcl)
+      #-(or ccl sbcl)
       (with-tracking-stream (stream source-path)
         (prog* ((*load-truename* (truename source-path))
                 (*load-pathname* source-path)

--- a/src/cl-jupyter/kernel.lisp
+++ b/src/cl-jupyter/kernel.lisp
@@ -626,7 +626,8 @@
          (ext:read-source stream nil stream nil
                           (kernel-environment kernel))
        (unless (eq form stream)
-         (eval-and-print form source breakpoints))))
+         (eval-and-print form source breakpoints)
+         t)))
     #+sbcl
     (source-path
       (with-accessors ((forms sb-c::file-info-forms)
@@ -686,16 +687,15 @@
       #+clasp
       (with-open-file (stream source-path)
         (ext:with-source-tracking (stream :pathname source-path)
-          (let ((*load-truename* (truename source-path))
-                (*load-pathname* source-path))
-            (tagbody
-             repeat
-               (ext:with-source-location
-                   ((ext:stream-source-location stream))
-                 (when (jupyter:evaluate-form jupyter:*kernel* stream source-path breakpoints
-                                              (ext:source-location-lineno (ext:current-source-location))
-                                              (1+ (ext:source-location-column (ext:current-source-location))))
-                   (go repeat)))))))
+          (prog ((*load-truename* (truename source-path))
+                 (*load-pathname* source-path))
+           repeat
+             (ext:with-source-location
+                 ((ext:stream-source-location stream))
+               (when (jupyter:evaluate-form jupyter:*kernel* stream source-path breakpoints
+                                            (ext:source-location-lineno (ext:current-source-location))
+                                            (1+ (ext:source-location-column (ext:current-source-location))))
+                 (go repeat))))))
       #+sbcl
       (sb-c::with-compiler-error-resignalling
         (prog* ((sb-c::*last-message-count* (list* 0 nil nil))


### PR DESCRIPTION
Fixes the code in cl-jupyter/kernel to use a new actually exported interface to source tracking in Clasp. Draft PR since I can change Clasp's interface if need be, it's not merged into Clasp yet, and I haven't tested this beyond making sure the system loads.